### PR TITLE
Feature/date type

### DIFF
--- a/app/race.ts
+++ b/app/race.ts
@@ -1,7 +1,7 @@
 export class Race {
   id: number;
   name: string;
-  date: date;
+  date: Date;
   about: string;
   entryFee: number;
   isRacing: boolean;

--- a/app/races.component.ts
+++ b/app/races.component.ts
@@ -29,8 +29,8 @@ export class RacesComponent {
     return sum;
   }
 
-  castDate(date) {
-    return new Date(date);
+  castDate(date: Date) {
+    return new Date(date.toString());
   }
 
   cashLeft() {


### PR DESCRIPTION
The Date object was throwing various errors that read that there needed to be proper typing of the Date. I found that in my own examples, and in running a clone of this example, both needed these updated to work properly in the end.
